### PR TITLE
Add event creation flow with admin login codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# Test
+# Group Availability Planner
+
+A single-page prototype that demonstrates a collaborative weekly scheduling interface. Participants mark their availability on a shared grid, and the app highlights common times for the entire group.
+
+## Features
+
+- **Event setup with admin codes** – Create a new event from the header, receive a unique admin login code, and use it to unlock admin-only tools later.
+- **Interactive weekly grid** – Click time slots to toggle availability for the current user.
+- **Participant management** – Logged-in admins can review other participants' schedules and clear them if necessary.
+- **Common availability view** – The common-times tab visualises overlap across all schedules and supports detailed hover tooltips.
+- **Persistent data** – Event details, participants, and schedules are saved to `localStorage`, so selections remain between visits on the same device.
+
+## Getting started
+
+Open `index.html` in a browser to explore the interface. On first load you'll be asked to name the event and yourself; the generated admin code unlocks the admin controls on future visits. No build step is required.
+
+## Tooltip details
+
+Hover over any slot in the Common Times grid to display a tooltip listing exactly who is available at that time. Keyboard users can focus the slot to view the same information.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,833 @@
+const DAYS = [
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+  "Sunday",
+];
+
+const HOURS = Array.from({ length: 24 }, (_, hour) => hour);
+
+const STORAGE_NAMESPACE = "group-availability-planner";
+const CURRENT_EVENT_KEY = `${STORAGE_NAMESPACE}:current-event-id`;
+const EVENT_KEY_PREFIX = `${STORAGE_NAMESPACE}:event:`;
+const USER_KEY_PREFIX = `${STORAGE_NAMESPACE}:user:`;
+const ADMIN_SESSION_PREFIX = `${STORAGE_NAMESPACE}:admin-session:`;
+
+let eventState = null;
+let schedules = new Map();
+let participants = [];
+let ADMIN_ID = "";
+let CURRENT_USER_ID = "";
+let viewedParticipantId = "";
+let adminSessionActive = false;
+let isAdmin = false;
+
+const myScheduleGrid = document.getElementById("myScheduleGrid");
+const commonAvailabilityGrid = document.getElementById("commonAvailabilityGrid");
+const participantList = document.getElementById("participantList");
+const deleteScheduleButton = document.getElementById("deleteScheduleButton");
+const tabsContainer = document.querySelector(".tabs");
+const tabButtons = Array.from(document.querySelectorAll("[data-tab-target]"));
+const tabPanels = Array.from(document.querySelectorAll("[data-tab-panel]"));
+const tooltip = document.getElementById("commonTimesTooltip");
+const eventNameDisplay = document.getElementById("eventNameDisplay");
+const currentUserDisplay = document.getElementById("currentUserDisplay");
+const adminCodeNotice = document.getElementById("adminCodeNotice");
+const createEventButton = document.getElementById("createEventButton");
+const adminLoginForm = document.getElementById("adminLoginForm");
+const adminCodeInput = document.getElementById("adminCodeInput");
+const adminStatusText = document.getElementById("adminStatusText");
+const adminLoginError = document.getElementById("adminLoginError");
+const adminLogoutButton = document.getElementById("adminLogoutButton");
+if (tooltip) {
+  tooltip.dataset.visible = "false";
+  tooltip.setAttribute("aria-hidden", "true");
+}
+
+if (createEventButton) {
+  createEventButton.addEventListener("click", handleCreateEventClick);
+}
+
+if (adminLoginForm) {
+  adminLoginForm.addEventListener("submit", handleAdminLoginSubmit);
+}
+
+if (adminLogoutButton) {
+  adminLogoutButton.addEventListener("click", handleAdminLogout);
+}
+
+function eventStorageKey(eventId) {
+  return `${EVENT_KEY_PREFIX}${eventId}`;
+}
+
+function userStorageKey(eventId) {
+  return `${USER_KEY_PREFIX}${eventId}`;
+}
+
+function adminSessionKey(eventId) {
+  return `${ADMIN_SESSION_PREFIX}${eventId}`;
+}
+
+function persistEvent(event) {
+  window.localStorage.setItem(eventStorageKey(event.id), JSON.stringify(event));
+}
+
+function applyEventState(event) {
+  eventState = event;
+  if (!Array.isArray(eventState.participants)) {
+    eventState.participants = [];
+  }
+  participants = eventState.participants;
+
+  const scheduleSource = eventState.schedules ?? {};
+  schedules = new Map();
+
+  participants.forEach((participant) => {
+    const rawSlots = Array.isArray(scheduleSource[participant.id])
+      ? scheduleSource[participant.id]
+      : [];
+    schedules.set(participant.id, new Set(rawSlots));
+  });
+
+  Object.entries(scheduleSource).forEach(([participantId, rawSlots]) => {
+    if (!schedules.has(participantId)) {
+      schedules.set(
+        participantId,
+        new Set(Array.isArray(rawSlots) ? rawSlots : [])
+      );
+    }
+  });
+
+  ADMIN_ID = eventState.adminParticipantId ?? "";
+}
+
+function saveEventState() {
+  if (!eventState) {
+    return;
+  }
+
+  const serialisedSchedules = {};
+  schedules.forEach((slots, participantId) => {
+    serialisedSchedules[participantId] = Array.from(slots).sort();
+  });
+
+  eventState.schedules = serialisedSchedules;
+  eventState.participants = participants;
+
+  persistEvent(eventState);
+}
+
+function loadExistingEvent() {
+  try {
+    const eventId = window.localStorage.getItem(CURRENT_EVENT_KEY);
+    if (!eventId) {
+      return null;
+    }
+
+    const raw = window.localStorage.getItem(eventStorageKey(eventId));
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = JSON.parse(raw);
+    parsed.id = eventId;
+    if (!Array.isArray(parsed.participants)) {
+      parsed.participants = [];
+    }
+    if (typeof parsed.schedules !== "object" || parsed.schedules === null) {
+      parsed.schedules = {};
+    }
+    return parsed;
+  } catch (error) {
+    console.warn("Unable to load event state", error);
+    return null;
+  }
+}
+
+function promptForValue(message, fallback) {
+  const value = window.prompt(message, fallback ?? "");
+  if (typeof value !== "string") {
+    return fallback ?? "";
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : fallback ?? "";
+}
+
+function normaliseName(name, fallback = "Guest") {
+  const trimmed = (name ?? "").trim();
+  if (!trimmed) {
+    return fallback;
+  }
+  return trimmed.replace(/\s+/g, " ");
+}
+
+function generateId(prefix) {
+  const randomPart = Math.random().toString(36).slice(2, 8);
+  const timePart = Date.now().toString(36).slice(-4);
+  return `${prefix}-${randomPart}${timePart}`;
+}
+
+function generateAdminCode() {
+  return Math.random().toString(36).slice(2, 8).toUpperCase();
+}
+
+function createParticipant(name) {
+  return {
+    id: generateId("participant"),
+    name: normaliseName(name, "Guest"),
+  };
+}
+
+function createEventData({ eventName, adminName }) {
+  const adminParticipant = createParticipant(adminName);
+  const eventId = generateId("event");
+  const adminCode = generateAdminCode();
+  return {
+    id: eventId,
+    name: normaliseName(eventName, "Untitled event"),
+    adminCode,
+    adminParticipantId: adminParticipant.id,
+    participants: [adminParticipant],
+    schedules: {
+      [adminParticipant.id]: [],
+    },
+  };
+}
+
+function clearEventSpecificState(eventId) {
+  if (!eventId) {
+    return;
+  }
+  window.localStorage.removeItem(userStorageKey(eventId));
+  window.localStorage.removeItem(adminSessionKey(eventId));
+}
+
+function promptCreateEvent() {
+  const eventName = promptForValue("Name your event:", "Team availability");
+  const adminName = promptForValue(
+    "Enter your name (you will be the admin):",
+    "Event host"
+  );
+
+  const event = createEventData({ eventName, adminName });
+  persistEvent(event);
+  window.localStorage.setItem(CURRENT_EVENT_KEY, event.id);
+  applyEventState(event);
+
+  CURRENT_USER_ID = event.adminParticipantId;
+  viewedParticipantId = CURRENT_USER_ID;
+  adminSessionActive = true;
+  refreshAdminState();
+
+  window.localStorage.setItem(userStorageKey(event.id), CURRENT_USER_ID);
+  window.localStorage.setItem(adminSessionKey(event.id), CURRENT_USER_ID);
+
+  if (typeof window.alert === "function") {
+    window.alert(
+      `Your admin code is ${event.adminCode}. Keep it somewhere safe to log in as admin later.`
+    );
+  }
+
+  return event;
+}
+
+function ensureCurrentUserId() {
+  if (!eventState) {
+    return "";
+  }
+
+  const key = userStorageKey(eventState.id);
+  const storedId = window.localStorage.getItem(key);
+  const existingParticipant = participants.find(
+    (participant) => participant.id === storedId
+  );
+
+  if (existingParticipant) {
+    return existingParticipant.id;
+  }
+
+  const name = promptForValue(
+    `Enter your name to join "${eventState.name ?? "Untitled event"}":`,
+    "Guest"
+  );
+
+  const participant = createParticipant(name);
+  participants.push(participant);
+  schedules.set(participant.id, new Set());
+  saveEventState();
+  window.localStorage.setItem(key, participant.id);
+  return participant.id;
+}
+
+function loadAdminSessionForCurrentUser() {
+  if (!eventState) {
+    return false;
+  }
+
+  const stored = window.localStorage.getItem(adminSessionKey(eventState.id));
+  return stored === CURRENT_USER_ID;
+}
+
+function refreshAdminState() {
+  isAdmin = CURRENT_USER_ID === ADMIN_ID && adminSessionActive;
+}
+
+function updateEventDetails() {
+  if (eventNameDisplay) {
+    eventNameDisplay.textContent = eventState?.name || "Untitled event";
+  }
+
+  if (currentUserDisplay) {
+    const participant = participants.find(
+      (item) => item.id === CURRENT_USER_ID
+    );
+    const baseName = participant ? participant.name : "";
+    const roleLabel =
+      CURRENT_USER_ID === ADMIN_ID
+        ? isAdmin
+          ? "Admin (unlocked)"
+          : "Admin (locked)"
+        : "Participant";
+    currentUserDisplay.textContent = baseName
+      ? `Signed in as ${baseName} · ${roleLabel}`
+      : roleLabel;
+  }
+
+  if (adminCodeNotice) {
+    if (isAdmin && eventState?.adminCode) {
+      adminCodeNotice.hidden = false;
+      adminCodeNotice.textContent = `Admin code: ${eventState.adminCode}`;
+    } else {
+      adminCodeNotice.hidden = true;
+      adminCodeNotice.textContent = "";
+    }
+  }
+}
+
+function updateAdminUi() {
+  if (!eventState) {
+    return;
+  }
+
+  if (adminStatusText) {
+    if (isAdmin) {
+      adminStatusText.textContent = "Admin tools unlocked.";
+    } else if (CURRENT_USER_ID === ADMIN_ID) {
+      adminStatusText.textContent = "Enter the admin code to unlock admin tools.";
+    } else {
+      adminStatusText.textContent = "Admin tools are reserved for the event creator.";
+    }
+  }
+
+  if (adminLoginForm) {
+    adminLoginForm.hidden = isAdmin || CURRENT_USER_ID !== ADMIN_ID;
+  }
+
+  if (adminLogoutButton) {
+    adminLogoutButton.hidden = !isAdmin;
+  }
+
+  if (adminLoginError) {
+    adminLoginError.hidden = true;
+    adminLoginError.textContent = "";
+  }
+
+  if (adminCodeInput) {
+    adminCodeInput.value = "";
+  }
+}
+
+function handleAdminLoginSubmit(event) {
+  event.preventDefault();
+
+  if (!eventState || CURRENT_USER_ID !== ADMIN_ID) {
+    return;
+  }
+
+  const code = adminCodeInput?.value?.trim();
+  if (!code) {
+    if (adminLoginError) {
+      adminLoginError.hidden = false;
+      adminLoginError.textContent = "Enter the admin code to continue.";
+    }
+    return;
+  }
+
+  if (code === eventState.adminCode) {
+    window.localStorage.setItem(adminSessionKey(eventState.id), CURRENT_USER_ID);
+    adminSessionActive = true;
+    refreshAdminState();
+    updateEventDetails();
+    updateAdminUi();
+    renderParticipantList();
+    updateDeleteButton();
+  } else if (adminLoginError) {
+    adminLoginError.hidden = false;
+    adminLoginError.textContent = "Incorrect admin code.";
+  }
+}
+
+function handleAdminLogout() {
+  if (!eventState) {
+    return;
+  }
+
+  window.localStorage.removeItem(adminSessionKey(eventState.id));
+  adminSessionActive = false;
+  refreshAdminState();
+  updateEventDetails();
+  updateAdminUi();
+  renderParticipantList();
+  updateDeleteButton();
+}
+
+function handleCreateEventClick() {
+  const proceed = window.confirm(
+    "Creating a new event will replace the current schedules stored on this device. Continue?"
+  );
+  if (!proceed) {
+    return;
+  }
+
+  clearEventSpecificState(eventState?.id);
+  promptCreateEvent();
+  updateEventDetails();
+  updateAdminUi();
+  renderParticipantList();
+  renderMyScheduleGrid();
+  renderCommonAvailabilityGrid();
+  updateDeleteButton();
+  setActiveTab("my-schedule");
+}
+
+function slotKey(dayIndex, hour) {
+  return `${dayIndex}:${hour}`;
+}
+
+function ensureSchedule(participantId) {
+  if (!schedules.has(participantId)) {
+    schedules.set(participantId, new Set());
+  }
+  return schedules.get(participantId);
+}
+
+function formatHour(hour) {
+  const suffix = hour >= 12 ? "PM" : "AM";
+  const normalised = hour % 12 === 0 ? 12 : hour % 12;
+  return `${normalised} ${suffix}`;
+}
+
+function formatHourShort(hour) {
+  const suffix = hour >= 12 ? "p" : "a";
+  const normalised = hour % 12 === 0 ? 12 : hour % 12;
+  return `${normalised}${suffix}`;
+}
+
+function formatHourRange(hour) {
+  const endHour = (hour + 1) % 24;
+  return `${formatHour(hour)} – ${formatHour(endHour)}`;
+}
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function renderMyScheduleGrid() {
+  const participant = participants.find((item) => item.id === viewedParticipantId);
+  const schedule = ensureSchedule(viewedParticipantId);
+  const editable = viewedParticipantId === CURRENT_USER_ID;
+
+  myScheduleGrid.innerHTML = "";
+
+  const fragment = document.createDocumentFragment();
+  fragment.append(createHeaderRow());
+
+  DAYS.forEach((day, dayIndex) => {
+    const row = createRow();
+    row.append(createCell("grid__cell grid__cell--day", day));
+
+    HOURS.forEach((hour) => {
+      const key = slotKey(dayIndex, hour);
+      const isAvailable = schedule.has(key);
+      const cellClasses = ["grid__cell"];
+      if (isAvailable) {
+        cellClasses.push("grid__cell--available");
+      } else {
+        cellClasses.push("grid__cell--empty");
+      }
+      if (editable) {
+        cellClasses.push("grid__cell--editable");
+      }
+
+      const cell = createCell(cellClasses.join(" "));
+      cell.dataset.dayIndex = String(dayIndex);
+      cell.dataset.hour = String(hour);
+      cell.dataset.slotKey = key;
+      cell.setAttribute("aria-label", `${day} ${formatHourRange(hour)} availability`);
+      cell.setAttribute("role", "button");
+      cell.setAttribute("aria-pressed", String(isAvailable));
+      cell.tabIndex = editable ? 0 : -1;
+
+      if (editable) {
+        cell.addEventListener("click", () => toggleAvailability(key));
+        cell.addEventListener("keydown", (event) => {
+          if (event.key === " " || event.key === "Enter") {
+            event.preventDefault();
+            toggleAvailability(key);
+          }
+        });
+      }
+
+      row.append(cell);
+    });
+
+    fragment.append(row);
+  });
+
+  myScheduleGrid.append(fragment);
+
+  const subtitle = document.querySelector("#my-schedule .panel__subtitle");
+  if (subtitle && participant) {
+    const canEditText = editable
+      ? "You're updating your own availability."
+      : `Viewing ${participant.name}'s schedule.`;
+    const instruction = editable
+      ? "Click a time slot to toggle availability."
+      : "Slots are read-only when previewing another participant.";
+    subtitle.textContent = `${canEditText} ${instruction}`;
+  }
+}
+
+function renderCommonAvailabilityGrid() {
+  commonAvailabilityGrid.innerHTML = "";
+
+  const fragment = document.createDocumentFragment();
+  fragment.append(createHeaderRow());
+
+  const totalParticipants = participants.length;
+
+  DAYS.forEach((day, dayIndex) => {
+    const row = createRow();
+    row.append(createCell("grid__cell grid__cell--day", day));
+
+    HOURS.forEach((hour) => {
+      const key = slotKey(dayIndex, hour);
+      const availableParticipants = participants.filter((participant) => {
+        const participantSchedule = ensureSchedule(participant.id);
+        return participantSchedule.has(key);
+      });
+      const availableNames = availableParticipants.map((participant) => participant.name);
+      const availableCount = availableParticipants.length;
+      const everyoneAvailable = availableCount === totalParticipants && totalParticipants > 0;
+      const hasAvailability = availableCount > 0;
+
+      const cell = createCell("grid__cell");
+      cell.dataset.dayIndex = String(dayIndex);
+      cell.dataset.hour = String(hour);
+      cell.dataset.count = String(availableCount);
+      cell.dataset.names = availableNames.join("|");
+      cell.setAttribute("tabindex", "0");
+
+      if (everyoneAvailable) {
+        cell.classList.add("grid__cell--common-all");
+        cell.textContent = "✔";
+      } else if (hasAvailability) {
+        cell.classList.add("grid__cell--common-partial");
+        cell.textContent = String(availableCount);
+      } else {
+        cell.classList.add("grid__cell--empty");
+      }
+
+      const description = hasAvailability
+        ? `${availableCount} participant${availableCount === 1 ? "" : "s"} available (${availableNames.join(", ")})`
+        : "No participants available";
+      cell.setAttribute("aria-label", `${day} ${formatHourRange(hour)} · ${description}`);
+
+      cell.addEventListener("mouseenter", (event) => handleTooltipEnter(event, cell));
+      cell.addEventListener("mousemove", handleTooltipMove);
+      cell.addEventListener("mouseleave", hideTooltip);
+      cell.addEventListener("focus", () => handleTooltipFocus(cell));
+      cell.addEventListener("blur", hideTooltip);
+
+      row.append(cell);
+    });
+
+    fragment.append(row);
+  });
+
+  commonAvailabilityGrid.append(fragment);
+  if (tooltip) {
+    commonAvailabilityGrid.append(tooltip);
+    hideTooltip();
+  }
+}
+
+function renderParticipantList() {
+  participantList.innerHTML = "";
+  const template = document.getElementById("participantListItemTemplate");
+
+  participants.forEach((participant) => {
+    const schedule = ensureSchedule(participant.id);
+    const clone = template.content.firstElementChild.cloneNode(true);
+    const button = clone.querySelector(".participant-list__button");
+    const badge = clone.querySelector(".participant-list__badge");
+
+    button.textContent = participant.name;
+    button.dataset.participantId = participant.id;
+    button.setAttribute("aria-current", String(viewedParticipantId === participant.id));
+    button.title = `${schedule.size} slot${schedule.size === 1 ? "" : "s"} selected`;
+
+    if (!isAdmin && participant.id !== CURRENT_USER_ID) {
+      button.disabled = true;
+    }
+
+    if (participant.id === ADMIN_ID && badge) {
+      badge.hidden = false;
+    }
+
+    button.addEventListener("click", () => {
+      if (!isAdmin && participant.id !== CURRENT_USER_ID) {
+        return;
+      }
+      viewedParticipantId = participant.id;
+      renderParticipantList();
+      renderMyScheduleGrid();
+      updateDeleteButton();
+    });
+
+    participantList.append(clone);
+  });
+}
+
+function updateDeleteButton() {
+  if (!isAdmin) {
+    deleteScheduleButton.hidden = true;
+    return;
+  }
+
+  deleteScheduleButton.hidden = false;
+  const schedule = ensureSchedule(viewedParticipantId);
+  const participant = participants.find((item) => item.id === viewedParticipantId);
+
+  deleteScheduleButton.disabled = schedule.size === 0;
+  deleteScheduleButton.textContent =
+    viewedParticipantId === CURRENT_USER_ID
+      ? "Clear my schedule"
+      : `Delete ${participant?.name ?? "participant"}'s schedule`;
+}
+
+function toggleAvailability(slot) {
+  const schedule = ensureSchedule(CURRENT_USER_ID);
+  if (schedule.has(slot)) {
+    schedule.delete(slot);
+  } else {
+    schedule.add(slot);
+  }
+  schedules.set(CURRENT_USER_ID, schedule);
+  saveEventState();
+  renderMyScheduleGrid();
+  renderCommonAvailabilityGrid();
+  renderParticipantList();
+  updateDeleteButton();
+}
+
+function clearSchedule(participantId) {
+  schedules.set(participantId, new Set());
+  saveEventState();
+}
+
+function handleTooltipEnter(event, cell) {
+  showTooltipForCell(cell, event.clientX, event.clientY);
+}
+
+function handleTooltipMove(event) {
+  positionTooltip(event.clientX, event.clientY);
+}
+
+function handleTooltipFocus(cell) {
+  const rect = cell.getBoundingClientRect();
+  const clientX = rect.left + rect.width / 2;
+  const clientY = rect.top + rect.height / 2;
+  showTooltipForCell(cell, clientX, clientY);
+}
+
+function showTooltipForCell(cell, clientX, clientY) {
+  const names = (cell.dataset.names || "")
+    .split("|")
+    .map((name) => name.trim())
+    .filter(Boolean);
+  const dayIndex = Number(cell.dataset.dayIndex);
+  const hour = Number(cell.dataset.hour);
+  const count = Number(cell.dataset.count ?? "0");
+
+  populateTooltip(dayIndex, hour, names, count);
+  tooltip.dataset.visible = "true";
+  tooltip.setAttribute("aria-hidden", "false");
+  positionTooltip(clientX, clientY);
+}
+
+function populateTooltip(dayIndex, hour, names, count) {
+  tooltip.innerHTML = "";
+
+  const title = document.createElement("p");
+  title.className = "tooltip__title";
+  title.textContent = `${DAYS[dayIndex]} · ${formatHourRange(hour)}`;
+  tooltip.append(title);
+
+  const subtitle = document.createElement("p");
+  subtitle.className = "tooltip__subtitle";
+  subtitle.textContent =
+    count > 0
+      ? `${count} participant${count === 1 ? " is" : "s are"} available`
+      : "No one is available in this slot";
+  tooltip.append(subtitle);
+
+  if (names.length > 0) {
+    const list = document.createElement("ul");
+    list.className = "tooltip__list";
+    names.forEach((name) => {
+      const item = document.createElement("li");
+      item.textContent = name;
+      list.append(item);
+    });
+    tooltip.append(list);
+  } else {
+    const empty = document.createElement("p");
+    empty.className = "tooltip__empty";
+    empty.textContent = "Everyone is busy.";
+    tooltip.append(empty);
+  }
+}
+
+function positionTooltip(clientX, clientY) {
+  const gridRect = commonAvailabilityGrid.getBoundingClientRect();
+  const x = clamp(clientX - gridRect.left, 12, gridRect.width - 12);
+  const y = clamp(clientY - gridRect.top, 12, gridRect.height - 12);
+  tooltip.style.left = `${x}px`;
+  tooltip.style.top = `${y}px`;
+  tooltip.dataset.visible = "true";
+}
+
+function hideTooltip() {
+  tooltip.dataset.visible = "false";
+  tooltip.setAttribute("aria-hidden", "true");
+}
+
+function createHeaderRow() {
+  const row = createRow();
+  row.append(createCell("grid__cell grid__cell--header"));
+  HOURS.forEach((hour) => {
+    row.append(createCell("grid__cell grid__cell--header", formatHourShort(hour)));
+  });
+  return row;
+}
+
+function createRow() {
+  const row = document.createElement("div");
+  row.className = "grid__row";
+  row.style.display = "contents";
+  return row;
+}
+
+function createCell(classes, text = "") {
+  const cell = document.createElement("div");
+  cell.className = classes;
+  cell.textContent = text;
+  return cell;
+}
+
+function initialiseApp() {
+  let event = loadExistingEvent();
+  let created = false;
+
+  if (!event) {
+    event = promptCreateEvent();
+    created = true;
+  } else {
+    applyEventState(event);
+  }
+
+  if (!created) {
+    CURRENT_USER_ID = ensureCurrentUserId();
+    viewedParticipantId = CURRENT_USER_ID;
+    adminSessionActive = loadAdminSessionForCurrentUser();
+    refreshAdminState();
+  }
+
+  if (!viewedParticipantId) {
+    viewedParticipantId = CURRENT_USER_ID;
+  }
+
+  updateEventDetails();
+  updateAdminUi();
+  renderParticipantList();
+  renderMyScheduleGrid();
+  renderCommonAvailabilityGrid();
+  updateDeleteButton();
+}
+
+function setActiveTab(targetId) {
+  tabButtons.forEach((button) => {
+    const isActive = button.dataset.tabTarget === targetId;
+    button.classList.toggle("tabs__button--active", isActive);
+  });
+
+  tabPanels.forEach((panel) => {
+    const isActive = panel.id === targetId;
+    panel.classList.toggle("tab-panel--active", isActive);
+  });
+
+  if (targetId !== "common-times") {
+    hideTooltip();
+  }
+}
+
+if (tabsContainer) {
+  tabsContainer.addEventListener("click", (event) => {
+    const button = event.target.closest(".tabs__button");
+    if (!button) {
+      return;
+    }
+    const targetId = button.dataset.tabTarget;
+    if (targetId) {
+      setActiveTab(targetId);
+    }
+  });
+}
+
+if (deleteScheduleButton) {
+  deleteScheduleButton.addEventListener("click", () => {
+    if (!isAdmin) {
+      return;
+    }
+    const participant = participants.find((item) => item.id === viewedParticipantId);
+    if (!participant) {
+      return;
+    }
+    const confirmationMessage =
+      viewedParticipantId === CURRENT_USER_ID
+        ? "Are you sure you want to clear your schedule?"
+        : `Delete ${participant.name}'s schedule?`;
+    const confirmed = window.confirm(confirmationMessage);
+    if (!confirmed) {
+      return;
+    }
+    clearSchedule(viewedParticipantId);
+    renderMyScheduleGrid();
+    renderCommonAvailabilityGrid();
+    renderParticipantList();
+    updateDeleteButton();
+  });
+}
+
+document.addEventListener("visibilitychange", () => {
+  if (document.hidden) {
+    hideTooltip();
+  }
+});
+
+initialiseApp();
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Group Availability Planner</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="app">
+      <header class="app__header">
+        <h1>Group Availability Planner</h1>
+        <p class="app__tagline">
+          Collaboratively capture weekly availability and discover times that work for everyone.
+        </p>
+        <div class="event-controls" id="eventControls">
+          <div class="event-controls__primary">
+            <h2 class="event-controls__name" id="eventNameDisplay"></h2>
+            <p class="event-controls__info" id="currentUserDisplay"></p>
+            <p class="event-controls__code" id="adminCodeNotice" hidden></p>
+          </div>
+          <div class="event-controls__actions">
+            <button class="event-controls__button" id="createEventButton" type="button">
+              Create new event
+            </button>
+            <form class="admin-login" id="adminLoginForm">
+              <label class="admin-login__label" for="adminCodeInput">Admin code</label>
+              <div class="admin-login__controls">
+                <input
+                  class="admin-login__input"
+                  id="adminCodeInput"
+                  type="password"
+                  name="adminCode"
+                  autocomplete="one-time-code"
+                  aria-describedby="adminStatusText adminLoginError"
+                />
+                <button class="admin-login__submit" type="submit">Log in</button>
+              </div>
+              <p class="admin-login__error" id="adminLoginError" role="alert" hidden></p>
+            </form>
+            <p class="admin-login__status" id="adminStatusText"></p>
+            <button class="event-controls__button" id="adminLogoutButton" type="button" hidden>
+              Log out
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <main class="app__body">
+        <section class="app__left">
+          <nav class="tabs" aria-label="Schedule views">
+            <button class="tabs__button tabs__button--active" data-tab-target="my-schedule" type="button">
+              My schedule
+            </button>
+            <button class="tabs__button" data-tab-target="common-times" type="button">
+              Common times
+            </button>
+          </nav>
+
+          <section
+            id="my-schedule"
+            class="tab-panel tab-panel--active"
+            aria-labelledby="my-schedule-tab"
+            data-tab-panel
+          >
+            <header class="panel__header">
+              <h2 class="panel__title">Weekly availability</h2>
+              <p class="panel__subtitle">
+                Click a time slot to toggle your availability. Admins can preview other participants.
+              </p>
+            </header>
+            <div class="grid" id="myScheduleGrid"></div>
+          </section>
+
+          <section id="common-times" class="tab-panel" aria-labelledby="common-times-tab" data-tab-panel>
+            <header class="panel__header">
+              <h2 class="panel__title">Common availability</h2>
+              <p class="panel__subtitle">
+                Green slots show times where everyone is available. Hover a slot to see who is free.
+              </p>
+            </header>
+            <div class="grid grid--common" id="commonAvailabilityGrid" aria-describedby="commonTimesHint">
+              <div id="commonTimesTooltip" class="tooltip" role="tooltip" aria-hidden="true"></div>
+            </div>
+            <p id="commonTimesHint" class="visually-hidden">
+              Hover a time slot to display the list of participants who are available at that time.
+            </p>
+          </section>
+        </section>
+
+        <aside class="app__sidebar" aria-label="Participants">
+          <header class="sidebar__header">
+            <h2>Participants</h2>
+            <p class="sidebar__description">
+              The event creator is automatically the admin and can review or delete schedules.
+            </p>
+          </header>
+          <ul class="participant-list" id="participantList"></ul>
+          <footer class="sidebar__footer">
+            <button class="sidebar__action" id="deleteScheduleButton" type="button">Delete schedule</button>
+          </footer>
+        </aside>
+      </main>
+    </div>
+
+    <template id="participantListItemTemplate">
+      <li class="participant-list__item">
+        <button class="participant-list__button" type="button"></button>
+        <span class="participant-list__badge" hidden>Admin</span>
+      </li>
+    </template>
+
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,592 @@
+:root {
+  color-scheme: light dark;
+  --color-background: #0f172a;
+  --color-surface: #111c34;
+  --color-panel: rgba(15, 23, 42, 0.6);
+  --color-border: rgba(148, 163, 184, 0.35);
+  --color-muted: #94a3b8;
+  --color-text: #e2e8f0;
+  --color-accent: #38bdf8;
+  --color-available: #22c55e;
+  --color-available-soft: rgba(34, 197, 94, 0.35);
+  --color-common: #22c55e;
+  --color-partial: rgba(56, 189, 248, 0.35);
+  --color-danger: #f87171;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #1e293b, #020617 60%);
+  color: var(--color-text);
+  display: flex;
+  justify-content: center;
+  padding: 3rem 1.5rem 4rem;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160"%3E%3Cg fill="none" stroke="%2365738b" stroke-width="0.5" opacity="0.2"%3E%3Cpath d="M0 .5H159.5V160"/%3E%3Cpath d="M.5 0V159.5H160"/%3E%3C/g%3E%3C/svg%3E') repeat;
+  opacity: 0.35;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.app {
+  width: min(1200px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  position: relative;
+}
+
+.app__header {
+  text-align: center;
+  padding: 2rem clamp(1rem, 2.5vw, 3rem);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.25), rgba(14, 116, 144, 0.35));
+  border-radius: 1.75rem;
+  box-shadow: 0 40px 80px rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(20px);
+}
+
+.app__header h1 {
+  font-size: clamp(2.1rem, 4vw, 2.8rem);
+  margin-bottom: 0.75rem;
+  color: white;
+}
+
+.app__tagline {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 1rem;
+  max-width: 48ch;
+  margin-inline: auto;
+}
+
+.event-controls {
+  margin-top: 1.75rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem 1.5rem;
+  align-items: flex-start;
+  justify-content: space-between;
+  text-align: left;
+}
+
+.event-controls__primary {
+  flex: 1 1 260px;
+  min-width: 220px;
+}
+
+.event-controls__name {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: white;
+}
+
+.event-controls__info {
+  margin: 0.35rem 0 0;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.event-controls__code {
+  margin: 0.6rem 0 0;
+  color: var(--color-accent);
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.event-controls__actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.event-controls__button {
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  background: rgba(15, 23, 42, 0.6);
+  color: white;
+  padding: 0.55rem 1.15rem;
+  border-radius: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.event-controls__button:hover,
+.event-controls__button:focus-visible {
+  background: rgba(56, 189, 248, 0.2);
+  box-shadow: 0 8px 20px rgba(14, 165, 233, 0.25);
+}
+
+.event-controls__button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.event-controls__button:active {
+  transform: translateY(1px);
+}
+
+.admin-login {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  width: min(280px, 100%);
+}
+
+.admin-login__label {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--color-muted);
+}
+
+.admin-login__controls {
+  display: flex;
+  align-items: stretch;
+  gap: 0.5rem;
+}
+
+.admin-login__input {
+  flex: 1 1 auto;
+  padding: 0.55rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.55);
+  color: white;
+  font: inherit;
+}
+
+.admin-login__input:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.admin-login__submit {
+  border: 0;
+  border-radius: 0.75rem;
+  padding: 0.55rem 1.1rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.85), rgba(56, 189, 248, 0.65));
+  color: white;
+  box-shadow: 0 12px 24px rgba(14, 165, 233, 0.3);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.admin-login__submit:hover,
+.admin-login__submit:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(14, 165, 233, 0.4);
+}
+
+.admin-login__submit:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.5);
+  outline-offset: 2px;
+}
+
+.admin-login__error {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-danger);
+}
+
+.admin-login__status {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-muted);
+}
+
+.app__body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 320px);
+  gap: 1.75rem;
+}
+
+.app__left {
+  background: rgba(15, 23, 42, 0.65);
+  border-radius: 1.5rem;
+  padding: 1.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.tabs {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(15, 23, 42, 0.4);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  padding: 0.4rem;
+  border-radius: 999px;
+  width: fit-content;
+}
+
+.tabs__button {
+  border: 0;
+  background: transparent;
+  color: var(--color-muted);
+  padding: 0.5rem 1.3rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tabs__button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.tabs__button--active {
+  background: rgba(56, 189, 248, 0.18);
+  color: white;
+  box-shadow: inset 0 0 0 1px rgba(14, 165, 233, 0.45);
+}
+
+.tab-panel {
+  display: none;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.tab-panel--active {
+  display: flex;
+}
+
+.panel__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.panel__title {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.panel__subtitle {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.grid {
+  display: grid;
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: 1.25rem;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.grid {
+  --grid-hour-width: 68px;
+  --grid-day-height: 48px;
+  grid-template-columns: 120px repeat(24, minmax(var(--grid-hour-width), 1fr));
+  grid-template-rows: 42px repeat(7, minmax(var(--grid-day-height), 1fr));
+}
+
+.grid--compact {
+  --grid-hour-width: 52px;
+  --grid-day-height: 44px;
+}
+
+.grid--common {
+  position: relative;
+}
+
+.grid__cell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+  color: var(--color-muted);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+  border-right: 1px solid rgba(148, 163, 184, 0.1);
+  transition: background 0.15s ease, color 0.15s ease, transform 0.15s ease;
+}
+
+.grid__cell:last-child {
+  border-right: 0;
+}
+
+.grid__cell--header {
+  font-weight: 600;
+  color: #e2e8f0;
+  background: rgba(15, 23, 42, 0.7);
+  backdrop-filter: blur(10px);
+}
+
+.grid__cell--day {
+  justify-content: flex-start;
+  padding-inline-start: 1rem;
+  font-weight: 600;
+  color: #f8fafc;
+  background: rgba(15, 23, 42, 0.65);
+}
+
+.grid__cell--available {
+  background: rgba(34, 197, 94, 0.3);
+  color: #ecfdf5;
+}
+
+.grid__cell--available:hover {
+  background: rgba(34, 197, 94, 0.45);
+}
+
+.grid__cell--editable {
+  cursor: pointer;
+}
+
+.grid__cell--editable:hover {
+  background: rgba(56, 189, 248, 0.15);
+}
+
+.grid__cell--common-all {
+  background: rgba(34, 197, 94, 0.75);
+  color: #f8fafc;
+  font-weight: 600;
+}
+
+.grid__cell--common-partial {
+  background: rgba(56, 189, 248, 0.1);
+  color: #bae6fd;
+}
+
+.grid__cell--empty {
+  background: rgba(15, 23, 42, 0.35);
+}
+
+.tooltip {
+  position: absolute;
+  inset: auto auto;
+  min-width: 180px;
+  max-width: 240px;
+  background: rgba(15, 23, 42, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  padding: 0.65rem 0.85rem;
+  border-radius: 0.9rem;
+  box-shadow: 0 18px 40px rgba(2, 6, 23, 0.45);
+  font-size: 0.85rem;
+  pointer-events: none;
+  opacity: 0;
+  transform: translate(-50%, -16px);
+  transition: opacity 0.15s ease;
+  backdrop-filter: blur(12px);
+  z-index: 5;
+}
+
+.tooltip[data-visible="true"] {
+  opacity: 1;
+}
+
+.tooltip__title {
+  margin: 0 0 0.35rem;
+  font-weight: 600;
+  color: #f1f5f9;
+  font-size: 0.9rem;
+}
+
+.tooltip__subtitle {
+  margin: 0 0 0.5rem;
+  color: var(--color-muted);
+  font-size: 0.8rem;
+}
+
+.tooltip__list {
+  margin: 0;
+  padding-left: 1rem;
+  color: #e2e8f0;
+}
+
+.tooltip__empty {
+  margin: 0;
+  color: #f8fafc;
+}
+
+.app__sidebar {
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: 1.5rem;
+  padding: 1.75rem 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.sidebar__header h2 {
+  margin: 0 0 0.35rem;
+  font-size: 1.3rem;
+  color: white;
+}
+
+.sidebar__description {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.participant-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.participant-list__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.participant-list__button {
+  flex: 1;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.5);
+  color: #e2e8f0;
+  padding: 0.55rem 0.85rem;
+  border-radius: 0.9rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.participant-list__button:hover,
+.participant-list__button:focus-visible {
+  border-color: rgba(56, 189, 248, 0.5);
+  color: white;
+}
+
+.participant-list__button[aria-current="true"] {
+  background: rgba(56, 189, 248, 0.25);
+  border-color: rgba(14, 165, 233, 0.6);
+}
+
+.participant-list__button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.participant-list__badge {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: rgba(15, 23, 42, 0.88);
+  background: #38bdf8;
+  border-radius: 999px;
+  padding: 0.2rem 0.65rem;
+}
+
+.sidebar__action {
+  width: 100%;
+  border: 0;
+  background: rgba(248, 113, 113, 0.15);
+  color: #fecaca;
+  border-radius: 0.9rem;
+  padding: 0.65rem 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.sidebar__action:hover,
+.sidebar__action:focus-visible {
+  background: rgba(248, 113, 113, 0.3);
+  color: white;
+}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 1080px) {
+  .app__body {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .app__sidebar {
+    order: -1;
+  }
+
+  .event-controls {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1.5rem;
+  }
+
+  .event-controls__actions {
+    width: 100%;
+  }
+}
+
+@media (max-width: 720px) {
+  body {
+    padding-inline: 1rem;
+  }
+
+  .grid {
+    --grid-hour-width: 48px;
+  }
+
+  .app__header {
+    padding: 1.5rem 1rem;
+  }
+
+  .event-controls__actions {
+    align-items: stretch;
+    gap: 0.9rem;
+  }
+
+  .admin-login__controls {
+    flex-direction: column;
+  }
+
+  .admin-login__submit {
+    width: 100%;
+  }
+}
+
+@media (max-width: 540px) {
+  .grid {
+    overflow-x: auto;
+    border-radius: 1rem;
+  }
+
+  .grid {
+    display: block;
+  }
+
+  .grid__row {
+    display: grid;
+    grid-template-columns: 120px repeat(24, minmax(48px, 1fr));
+  }
+
+  .event-controls__primary {
+    min-width: 0;
+  }
+}


### PR DESCRIPTION
## Summary
- add header controls to create a new event, show the current user, and unlock admin tools with a login code
- persist event, participant, and schedule data in localStorage with admin sessions gated by the generated code
- refresh styling and docs to explain the event/admin workflow

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e127d98268832aa59f653abc4bcf33